### PR TITLE
fix: escaping characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,6 @@ func GenerateProfileCard(w http.ResponseWriter, r *http.Request) {
 		handleError(w, err, http.StatusInternalServerError)
 		return
 	}
-	escapeNonArrayTemplateDate(&data)
 	data.Preview = false
 	pdfBytes, err := GeneratePDF(&data, "./public/templates/aoe-profile-card.html")
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -5,14 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"html"
 	"image/jpeg"
 	"image/png"
 	"io"
 	"log"
 	"mime/multipart"
 	"net/http"
-	"reflect"
 )
 
 // GenerateTemplateData extracts the relevant data from a multipart form and returns types.TemplateData
@@ -124,19 +122,8 @@ func deleteAndEscapeStringArr(s []string) []string {
 	var r []string
 	for _, str := range s {
 		if str != "" {
-			r = append(r, html.EscapeString(str))
+			r = append(r, str)
 		}
 	}
 	return r
-}
-
-func escapeNonArrayTemplateDate(data *TemplateData) {
-	value := reflect.ValueOf(data).Elem()
-	for i := 0; i < value.NumField(); i++ {
-		field := value.Field(i)
-		if field.Type() == reflect.TypeOf("") {
-			str := field.Interface().(string)
-			field.SetString(html.EscapeString(str))
-		}
-	}
 }


### PR DESCRIPTION
I had a rendering problem with the " ' ". 
<img width="56" height="19" alt="Screenshot 2025-07-18 at 15 28 51" src="https://github.com/user-attachments/assets/55e39f69-5fb0-4723-baef-68e859f6cba8" />
So I made a quick fix for not escaping special characters.
Now I get this.
<img width="64" height="19" alt="Screenshot 2025-07-18 at 15 30 23" src="https://github.com/user-attachments/assets/69f14de0-ef3f-49b6-8d88-53f336139eb3" />

Since I'm not that experienced in go and even though it's just a quick and dirty workaround, please give it a review and maybe an improvement. :)
